### PR TITLE
chore: add default config file path to run command

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,4 +37,4 @@ debug:
     npx @modelcontextprotocol/inspector {{hyper_mcp_bin}} --config-file ~/.config/hyper-mcp/config.json
 
 run:
-    cargo run
+    cargo run -- --config-file ~/.config/hyper-mcp/config.json


### PR DESCRIPTION
On macOS, the default config directory is located at `$HOME/Library/Application Support/hyper-mcp/config.json` rather than `~/.config/hyper-mcp/config.json`.

The current "just run" command fails with: Failed to read config file at "/Users/ntheanh201/Library/Application Support/hyper-mcp/config.json": No such file or directory (os error 2)