### PR TITLE
Return `RegistryAuth::Anonymous` when unable to fetch credentials

### DIFF
--- a/src/oci.rs
+++ b/src/oci.rs
@@ -54,7 +54,7 @@ fn build_auth(reference: &Reference) -> RegistryAuth {
                 "Error retrieving docker credentials: {}. Using anonymous auth",
                 e
             );
-            return RegistryAuth::Anonymous;
+            RegistryAuth::Anonymous
         }
         Ok(DockerCredential::UsernamePassword(username, password)) => {
             info!("Found docker credentials");

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -49,7 +49,13 @@ fn build_auth(reference: &Reference) -> RegistryAuth {
     match docker_credential::get_credential(server) {
         Err(CredentialRetrievalError::ConfigNotFound) => RegistryAuth::Anonymous,
         Err(CredentialRetrievalError::NoCredentialConfigured) => RegistryAuth::Anonymous,
-        Err(e) => panic!("Error handling docker configuration file: {}", e),
+        Err(e) => {
+            info!(
+                "Error retrieving docker credentials: {}. Using anonymous auth",
+                e
+            );
+            return RegistryAuth::Anonymous;
+        }
         Ok(DockerCredential::UsernamePassword(username, password)) => {
             info!("Found docker credentials");
             RegistryAuth::Basic(username, password)


### PR DESCRIPTION
This allows users without authentication to pull public plugins. The issue only seems to occur on macOS when credentials are stored in Keychain.

```console
king@blackhole ~ [SIGINT] $ hyper-mcp -c ~/.config/hyper-mcp/config.json

thread 'main' panicked at src/oci.rs:52:19:
Error handling docker configuration file: Credential helper returned non-zero response code:
stdout:
credentials not found in native keychain


stderr:


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```