### PR TITLE
Feat: make a better logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,33 +15,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
-    - name: Install WASM target
-      run: rustup target add wasm32-wasip1
+      - name: Install WASM target
+        run: rustup target add wasm32-wasip1
 
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: "., examples/plugins/*"
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "., examples/plugins/*"
 
-    - name: Build hyper-mcp
-      run: cargo build
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
 
-    - name: Build example plugins
-      run: |
-        for plugin in qr-code hash myip fetch fs; do
-          echo "Building plugin: $plugin"
-          cargo build --release --target wasm32-wasip1 --manifest-path "examples/plugins/$plugin/Cargo.toml"
-        done
+      - name: Check formatting
+        run: cargo fmt -- --check
 
-    - name: Run clippy
-      run: cargo clippy -- -D warnings
+      - name: Build hyper-mcp
+        run: cargo build
 
-    - name: Check formatting
-      run: cargo fmt -- --check 
+      - name: Build example plugins
+        run: |
+          for plugin in qr-code hash myip fetch fs; do
+            echo "Building plugin: $plugin"
+            cargo build --release --target wasm32-wasip1 --manifest-path "examples/plugins/$plugin/Cargo.toml"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/.vscode
+.DS_Store
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,9 +326,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -336,7 +336,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
  "serde",
@@ -781,6 +781,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1264,12 +1287,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
  "clap",
  "dirs 6.0.0",
  "docker_credential",
+ "env_logger",
  "extism",
  "flate2",
  "hex",
+ "log",
  "maplit",
  "oci-client",
  "reqwest",
@@ -1279,8 +1305,6 @@ dependencies = [
  "sha2",
  "tar",
  "tokio",
- "tracing",
- "tracing-subscriber",
  "url",
 ]
 
@@ -1605,6 +1629,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mach2"
@@ -2018,6 +2066,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -2726,9 +2789,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2884,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -2899,15 +2962,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ license = "Apache-2.0"
 tokio = { version = "1.44", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tracing = "0.1"
-tracing-subscriber = "0.3"
 reqwest = { version = "0.12", features = ["json"] }
 base64 = "0.22.1"
 anyhow = "1.0.97"
@@ -27,6 +25,9 @@ hex = "0.4.3"
 oci-client = "0.14.0"
 tar = "0.4.44"
 flate2 = "1.1.0"
-clap = { version = "4.5.32", features = ["derive"] }
+clap = { version = "4.5.32", features = ["derive", "env"] }
 dirs = "6.0"
 docker_credential = "1.3.1"
+log = "0.4.27"
+env_logger = "0.11.7"
+chrono = "0.4.40"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use chrono::Local;
+use log::LevelFilter;
+use std::{io::Write, str::FromStr};
+
+pub(crate) fn init_logger(path: Option<&str>, level: Option<&str>) -> Result<()> {
+    let log_level = LevelFilter::from_str(level.unwrap_or("info"))?;
+
+    // If the log path is not provided, use the stderr
+    let log_file = match path {
+        Some(p) => Box::new(
+            std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(p)?,
+        ) as Box<dyn Write + Send + Sync + 'static>,
+        _ => Box::new(std::io::stderr()) as Box<dyn Write + Send + Sync + 'static>,
+    };
+
+    // TODO: apply module filter
+    env_logger::Builder::new()
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{}/{}:{} {} [{}] - {}",
+                record.module_path().unwrap_or("unknown"),
+                basename(record.file().unwrap_or("unknown")),
+                record.line().unwrap_or(0),
+                Local::now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+                record.level(),
+                record.args()
+            )
+        })
+        .target(env_logger::Target::Pipe(log_file))
+        .filter(None, log_level)
+        .try_init()?;
+
+    Ok(())
+}
+
+pub fn basename(path: &str) -> String {
+    path.split('/').last().unwrap_or(path).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basename() {
+        assert_eq!(basename("/path/to/file.txt"), "file.txt");
+        assert_eq!(basename("file.txt"), "file.txt");
+        assert_eq!(basename("file"), "file");
+        assert_eq!(basename("/path/to/"), "");
+        assert_eq!(basename(""), "");
+    }
+
+    #[test]
+    fn test_init_logger() {
+        // Test with a valid path
+        let result = init_logger(Some("test.log"), Some("debug"));
+        assert!(result.is_ok());
+
+        // Test with an invalid path
+        let result = init_logger(Some("/invalid/path/to/log.log"), Some("debug"));
+        assert!(result.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ use std::io;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
-mod r#mod;
 mod config;
+mod r#mod;
 mod oci;
 mod prompts;
 mod resources;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3,7 +3,6 @@ use crate::PluginManager;
 use super::types::*;
 use rpc_router::{HandlerResult, IntoHandlerError};
 use serde_json::json;
-use tracing::error;
 
 pub async fn tools_list(
     pm: PluginManager,
@@ -18,7 +17,7 @@ pub async fn tools_list(
                 payload.tools.extend(parsed.tools);
             }
             Err(e) => {
-                error!("tool {} describe() error: {}", key, e.to_string());
+                log::error!("tool {} describe() error: {}", key, e);
             }
         }
     }
@@ -44,11 +43,7 @@ pub async fn tools_call(
             Ok(result) => match serde_json::from_str::<CallToolResult>(result) {
                 Ok(parsed) => Ok(parsed),
                 Err(e) => {
-                    error!(
-                        "Failed to deserialize data: {} with {}",
-                        result,
-                        e.to_string()
-                    );
+                    log::error!("Failed to deserialize data: {} with {}", result, e);
                     Err(
                         json!({"code": -32602, "message": "Failed to deserialized data"})
                             .into_handler_error(),
@@ -56,11 +51,7 @@ pub async fn tools_call(
                 }
             },
             Err(e) => {
-                error!(
-                    "Failed to execute plugin: {}, request: {:?}",
-                    e.to_string(),
-                    request
-                );
+                log::error!("Failed to execute plugin: {}, request: {:?}", e, request);
                 Err(
                     json!({"code": -32602, "message": "Failed to execute plugin"})
                         .into_handler_error(),


### PR DESCRIPTION
### Changes
- Implemented a new logging method.** Output will be redirected to `--log.file` if provided; otherwise, it defaults to `stderr`. This change does not affect MCP clients listening to `stdout`.  
- Refactored** the `tracing` logger to use `log` instead.
- Reorder steps in the CI workflow. Move these lint steps to the top (fail-fast strategy).