### PR TITLE
Update mcp.json in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ You can configure hyper-mcp either globally for all projects or specifically for
 {
   "mcpServers": {
     "hyper-mcp": {
-      "command": "/path/to/hyper-mcp",
-      "args": [""]
+      "command": "/path/to/hyper-mcp"
     }
   }
 }


### PR DESCRIPTION
On my Mac, Cursor cannot run in stdio mode if args is set to [""]. Please remove the args field from .cursor/mcp.json to ensure compatibility.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/7fa901e6-b346-4a94-9348-576cd74fe061" />
