### PR TITLE
Namespacing to prevent plugin tool name collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
+      - name: Run tests
+        run: cargo test --workspace --all-features
+
       - name: Build hyper-mcp
         run: cargo build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,6 +2528,8 @@ dependencies = [
  "hex",
  "log",
  "oci-client",
+ "once_cell",
+ "regex",
  "reqwest",
  "rmcp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,37 +13,39 @@ homepage = "https://github.com/tuananh/hyper-mcp"
 documentation = "https://github.com/tuananh/hyper-mcp"
 
 [dependencies]
-tokio = { version = "1.45.1", features = ["full"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-reqwest = { version = "0.12.21", features = ["json"] }
 anyhow = "1.0.98"
-extism = "1.11.1"
-sha2 = "0.10.9"
-hex = "0.4.3"
-oci-client = "0.15.0"
-tar = "0.4.44"
-flate2 = "1.1.2"
+aws-config = { version = "1.8.2", features = ["behavior-version-latest"] }
+aws-sdk-s3 = "1.98.0"
+axum = "0.8.4"
+bytesize = "2.0.1"
 clap = { version = "4.5.40", features = ["derive", "env"] }
 dirs = "6.0.0"
 docker_credential = "1.3.2"
+extism = "1.11.1"
+flate2 = "1.1.2"
+hex = "0.4.3"
 log = "0.4.27"
-sigstore = { version = "0.12.1", features = ["cosign", "verify", "bundle"] }
-tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+oci-client = "0.15.0"
+once_cell = "1.21.3"
 rmcp = { version = "0.3.2", features = [
     "server",
     "transport-io",
     "transport-sse-server",
     "transport-streamable-http-server",
 ] }
+regex = { version = "1.11.1", features = ["unicode", "perf"] }
+reqwest = { version = "0.12.21", features = ["json"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 serde_yaml = "0.9.34"
+sha2 = "0.10.9"
+sigstore = { version = "0.12.1", features = ["cosign", "verify", "bundle"] }
+tar = "0.4.44"
+tokio = { version = "1.45.1", features = ["full"] }
 toml = "0.9.0"
-bytesize = "2.0.1"
-axum = "0.8.4"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
-aws-config = { version = "1.8.2", features = ["behavior-version-latest"] }
-aws-sdk-s3 = "1.98.0"
 
 [[bin]]
 name = "hyper-mcp"

--- a/README.md
+++ b/README.md
@@ -54,36 +54,30 @@ Built with security-first mindset:
 
 ```json
 {
-  "plugins": [
-    {
-      "name": "time",
+  "plugins": {}
+    "time": {
       "url": "oci://ghcr.io/tuananh/time-plugin:latest"
     },
-    {
-      "name": "qr-code",
+    "qr-code": {
       "url": "oci://ghcr.io/tuananh/qrcode-plugin:latest"
     },
-    {
-      "name": "hash",
+    "hash": {
       "url": "oci://ghcr.io/tuananh/hash-plugin:latest"
     },
-    {
-      "name": "myip",
+    "myip": {
       "url": "oci://ghcr.io/tuananh/myip-plugin:latest",
       "runtime_config": {
         "allowed_hosts": ["1.1.1.1"]
       }
     },
-    {
-      "name": "fetch",
+    "fetch": {
       "url": "oci://ghcr.io/tuananh/fetch-plugin:latest",
       "runtime_config": {
         "allowed_hosts": ["*"],
         "memory_limit": "100 MB",
-        "tool_name_prefix": "foo_"
       }
     }
-  ]
+  }
 }
 ```
 

--- a/RUNTIME_CONFIG.md
+++ b/RUNTIME_CONFIG.md
@@ -13,15 +13,14 @@ The configuration is structured as follows:
     - **allowed_paths** (`array[string]`, optional): List of allowed file system paths.
     - **env_vars** (`object`, optional): Key-value pairs of environment variables for the plugin.
     - **memory_limit** (`string`, optional): Memory limit for the plugin (e.g., `"512Mi"`).
-    - **tool_name_prefix** (`string`, optional): Optional prefix for tool names. Can be use to prevent tool name collision.
 
 ## Example (YAML)
 
 ```yaml
 plugins:
-  - name: time
+  - time:
     path: oci://ghcr.io/tuananh/time-plugin:latest
-  - name: myip
+  - myip:
     path: oci://ghcr.io/tuananh/myip-plugin:latest
     runtime_config:
       allowed_hosts:
@@ -37,23 +36,20 @@ plugins:
 
 ```json
 {
-  "plugins": [
-    {
-      "name": "time",
+  "plugins": {
+    "time": {
       "path": "oci://ghcr.io/tuananh/time-plugin:latest"
     },
-    {
-      "name": "myip",
+    "myip": {
       "path": "oci://ghcr.io/tuananh/myip-plugin:latest",
       "runtime_config": {
         "allowed_hosts": ["1.1.1.1"],
         "skip_tools": ["debug"],
         "env_vars": {"FOO": "bar"},
         "memory_limit": "512Mi",
-        "tool_name_prefix": "foo_"
       }
     }
-  ]
+  }
 }
 ```
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,30 +1,25 @@
 {
-  "plugins": [
-    {
-      "name": "time",
+  "plugins": {
+    "time": {
       "url": "oci://ghcr.io/tuananh/time-plugin:latest"
     },
-    {
-      "name": "qr-code",
+    "qr-code": {
       "url": "oci://ghcr.io/tuananh/qrcode-plugin:latest"
     },
-    {
-      "name": "hash",
+    "hash": {
       "url": "oci://ghcr.io/tuananh/hash-plugin:latest"
     },
-    {
-      "name": "myip",
+    "myip": {
       "url": "oci://ghcr.io/tuananh/myip-plugin:latest",
       "runtime_config": {
         "allowed_hosts": ["1.1.1.1"]
       }
     },
-    {
-      "name": "fetch",
+    "fetch": {
       "url": "oci://ghcr.io/tuananh/fetch-plugin:latest",
       "runtime_config": {
         "allowed_hosts": ["*"]
       }
     }
-  ]
+  }
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,17 +1,17 @@
 ---
 plugins:
-  - name: time
+  time:
     url: oci://ghcr.io/tuananh/time-plugin:latest
-  - name: qr-code
+  qr-code:
     url: oci://ghcr.io/tuananh/qrcode-plugin:latest
-  - name: hash
+  hash:
     url: oci://ghcr.io/tuananh/hash-plugin:latest
-  - name: myip
+  myip:
     url: oci://ghcr.io/tuananh/myip-plugin:latest
     runtime_config:
       allowed_hosts:
         - "1.1.1.1"
-  - name: fetch
+  fetch:
     url: oci://ghcr.io/tuananh/fetch-plugin:latest
     runtime_config:
       allowed_hosts:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,68 @@
 use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::Path;
+use std::{collections::HashMap, convert::TryFrom, fmt, path::Path, str::FromStr};
 use url::Url;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct PluginName(String);
+
+#[derive(Debug, Clone)]
+pub struct PluginNameParseError;
+
+impl fmt::Display for PluginNameParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to parse plugin name")
+    }
+}
+
+impl std::error::Error for PluginNameParseError {}
+
+static PLUGIN_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*$").expect("Failed to compile plugin name regex")
+});
+
+impl PluginName {
+    #[allow(dead_code)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for PluginName {
+    type Error = PluginNameParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if PLUGIN_NAME_REGEX.is_match(value) {
+            Ok(PluginName(value.to_owned()))
+        } else {
+            Err(PluginNameParseError)
+        }
+    }
+}
+
+impl FromStr for PluginName {
+    type Err = PluginNameParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        PluginName::try_from(s)
+    }
+}
+
+impl fmt::Display for PluginName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
-    pub plugins: Vec<PluginConfig>,
+    pub plugins: HashMap<PluginName, PluginConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PluginConfig {
-    pub name: String,
     #[serde(rename = "url", alias = "path")]
     pub url: Url,
     pub runtime_config: Option<RuntimeConfig>,
@@ -25,7 +76,6 @@ pub struct RuntimeConfig {
     pub allowed_paths: Option<Vec<String>>,
     pub env_vars: Option<HashMap<String, String>>,
     pub memory_limit: Option<String>,
-    pub tool_name_prefix: Option<String>,
 }
 
 pub async fn load_config(path: &Path) -> Result<Config> {
@@ -49,4 +99,72 @@ pub async fn load_config(path: &Path) -> Result<Config> {
     };
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plugin_name_valid() {
+        let valid_names = vec![
+            "plugin1",
+            "plugin-name",
+            "plugin_name",
+            "PluginName",
+            "plugin123",
+            "plugin-name_123",
+        ];
+
+        for name in valid_names {
+            assert!(
+                PluginName::try_from(name).is_ok(),
+                "Failed to parse valid name: {}",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_plugin_name_invalid() {
+        let invalid_names = vec![
+            "plugin name",  // spaces not allowed
+            "plugin@name",  // special characters not allowed
+            "-pluginname",  // cannot start with hyphen
+            "pluginname-",  // cannot end with hyphen
+            "_pluginname",  // cannot start with underscore
+            "pluginname_",  // cannot end with underscore
+            "plugin--name", // consecutive hyphens not allowed
+            "plugin__name", // consecutive underscores not allowed
+            "",             // empty string
+        ];
+        for name in invalid_names {
+            assert!(
+                PluginName::try_from(name).is_err(),
+                "Parsed invalid name: {}",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_plugin_name_display() {
+        let name_str = "plugin-name_123";
+        let plugin_name = PluginName::try_from(name_str).unwrap();
+        assert_eq!(plugin_name.to_string(), name_str);
+    }
+
+    #[test]
+    fn test_plugin_name_serialize_deserialize() {
+        let name_str = "plugin-name_123";
+        let plugin_name = PluginName::try_from(name_str).unwrap();
+
+        // Serialize
+        let serialized = serde_json::to_string(&plugin_name).unwrap();
+        assert_eq!(serialized, format!("\"{}\"", name_str));
+
+        // Deserialize
+        let deserialized: PluginName = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, plugin_name);
+    }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,26 +1,70 @@
-use crate::Cli;
-use crate::config::{Config, load_config};
-use crate::oci::pull_and_extract_oci_image;
+use crate::{
+    Cli,
+    config::{Config, PluginName, PluginNameParseError, load_config},
+    oci::pull_and_extract_oci_image,
+};
 use anyhow::Result;
+use aws_sdk_s3::Client as S3Client;
 use bytesize::ByteSize;
 use extism::{Manifest, Plugin, Wasm};
-use rmcp::service::{NotificationContext, RequestContext, RoleServer};
-use rmcp::{ErrorData as McpError, ServerHandler, model::*};
-use std::str::FromStr;
-
-use aws_sdk_s3::Client as S3Client;
 use oci_client::Client as OciClient;
+use rmcp::{
+    ErrorData as McpError, ServerHandler,
+    model::*,
+    service::{NotificationContext, RequestContext, RoleServer},
+};
 use serde_json::json;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    fmt,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 use tokio::sync::{OnceCell, RwLock};
+
+#[derive(Debug, Clone)]
+pub struct ToolNameParseError;
+
+impl fmt::Display for ToolNameParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to parse tool name")
+    }
+}
+
+impl std::error::Error for ToolNameParseError {}
+
+impl From<PluginNameParseError> for ToolNameParseError {
+    fn from(_: PluginNameParseError) -> Self {
+        ToolNameParseError
+    }
+}
+
+fn create_namespaced_tool_name(
+    plugin_name: &PluginName,
+    tool_name: &str,
+) -> Result<String, ToolNameParseError> {
+    if tool_name.contains("::") {
+        // If the tool name already contains '::', return it as is to avoid ambiguity
+        return Err(ToolNameParseError);
+    }
+    Ok(format!("{plugin_name}::{tool_name}"))
+}
+
+fn parse_namespaced_tool_name(
+    tool_name: std::borrow::Cow<'static, str>,
+) -> Result<(PluginName, String), ToolNameParseError> {
+    let parts: Vec<&str> = tool_name.split("::").collect();
+    if parts.len() != 2 {
+        return Err(ToolNameParseError);
+    }
+    Ok((PluginName::from_str(parts[0])?, parts[1].to_string()))
+}
 
 #[derive(Clone)]
 pub struct PluginService {
     config: Config,
-    plugins: Arc<RwLock<HashMap<String, Arc<Mutex<Plugin>>>>>,
-    tool_plugin_map: Arc<RwLock<HashMap<String, String>>>,
+    plugins: Arc<RwLock<HashMap<PluginName, Arc<Mutex<Plugin>>>>>,
 }
 
 impl PluginService {
@@ -40,7 +84,6 @@ impl PluginService {
         let service = Self {
             config: load_config(config_path).await?,
             plugins: Arc::new(RwLock::new(HashMap::new())),
-            tool_plugin_map: Arc::new(RwLock::new(HashMap::new())),
         };
 
         service.load_plugins(cli).await?;
@@ -51,7 +94,7 @@ impl PluginService {
         let oci_client: OnceCell<OciClient> = OnceCell::new();
         let s3_client: OnceCell<S3Client> = OnceCell::new();
 
-        for plugin_cfg in &self.config.plugins {
+        for (plugin_name, plugin_cfg) in &self.config.plugins {
             let wasm_content = match plugin_cfg.url.scheme() {
                 "file" => tokio::fs::read(plugin_cfg.url.path()).await?,
                 "http" | "https" => reqwest::get(plugin_cfg.url.as_str())
@@ -75,7 +118,7 @@ impl PluginService {
                     std::fs::create_dir_all(&cache_dir)?;
 
                     let local_output_path =
-                        cache_dir.join(format!("{}-{}.wasm", plugin_cfg.name, short_hash));
+                        cache_dir.join(format!("{plugin_name}-{short_hash}.wasm"));
                     let local_output_path = local_output_path.to_str().unwrap();
 
                     if let Err(e) = pull_and_extract_oci_image(
@@ -94,11 +137,7 @@ impl PluginService {
                         log::error!("Error pulling oci plugin: {e}");
                         return Err(anyhow::anyhow!("Failed to pull OCI plugin: {}", e));
                     }
-                    log::info!(
-                        "cache plugin `{}` to : {}",
-                        plugin_cfg.name,
-                        local_output_path
-                    );
+                    log::info!("cache plugin `{plugin_name}` to : {local_output_path}");
                     tokio::fs::read(local_output_path).await?
                 }
                 "s3" => {
@@ -178,50 +217,7 @@ impl PluginService {
                 }
             }
             let plugin = Arc::new(Mutex::new(Plugin::new(&manifest, [], true).unwrap()));
-            let plugin_clone = Arc::clone(&plugin);
 
-            // Try to get tool information from the plugin and populate the cache
-            let describe_result = tokio::task::spawn_blocking(move || {
-                let mut plugin = plugin_clone.lock().unwrap();
-                plugin.call::<&str, String>("describe", "")
-            })
-            .await;
-
-            if let Ok(Ok(result)) = describe_result {
-                if let Ok(parsed) = serde_json::from_str::<ListToolsResult>(&result) {
-                    let mut cache = self.tool_plugin_map.write().await;
-                    let skip_tools = plugin_cfg
-                        .runtime_config
-                        .as_ref()
-                        .and_then(|rc| rc.skip_tools.clone())
-                        .unwrap_or_default();
-                    for tool in parsed.tools {
-                        if skip_tools.iter().any(|s| s == tool.name.as_ref() as &str) {
-                            log::info!("Skipping tool {} as requested in skip_tools", tool.name);
-                            continue;
-                        }
-                        log::info!("Saving tool {}/{} to cache", plugin_cfg.name, tool.name);
-                        // Check if the tool name already exists in another plugin
-                        if let Some(existing_plugin) = cache.get(&tool.name.to_string()) {
-                            if existing_plugin != &plugin_cfg.name {
-                                log::error!(
-                                    "Tool name collision detected: {} is provided by both {} and {} plugins",
-                                    tool.name,
-                                    existing_plugin,
-                                    plugin_cfg.name
-                                );
-                                panic!(
-                                    "Tool name collision detected: {} is provided by both {} and {} plugins",
-                                    tool.name, existing_plugin, plugin_cfg.name
-                                );
-                            }
-                        }
-                        cache.insert(tool.name.to_string(), plugin_cfg.name.clone());
-                    }
-                }
-            }
-
-            let plugin_name = plugin_cfg.name.clone();
             self.plugins
                 .write()
                 .await
@@ -251,101 +247,68 @@ impl ServerHandler for PluginService {
         request: CallToolRequestParam,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let plugins = self.plugins.read().await;
-        let tool_cache = self.tool_plugin_map.read().await;
-
-        let tool_name = request.name.clone();
-        let tool_name_str = tool_name.to_string();
-
-        // Find the plugin name and strip the prefix if needed
-        let mut original_name = tool_name_str.clone();
-        let mut plugin_name_for_tool = None;
-
-        // First try to find the tool directly in the cache
-        if let Some(plugin_name) = tool_cache.get(&tool_name_str) {
-            plugin_name_for_tool = Some(plugin_name.clone());
-
-            // Check if this tool has a prefix that needs to be stripped
-            for plugin_cfg in &self.config.plugins {
-                if let Some(rt_config) = &plugin_cfg.runtime_config {
-                    if let Some(tool_name_prefix) = &rt_config.tool_name_prefix {
-                        if tool_name_str.starts_with(tool_name_prefix) {
-                            // Strip the prefix to get the original tool name
-                            original_name = tool_name_str[tool_name_prefix.len()..].to_string();
-                            log::info!(
-                                "Found tool with prefix, stripping for internal call: {tool_name_str} -> {original_name}"
-                            );
-                            break;
-                        }
-                    }
-                }
+        let (plugin_name, tool_name) = match parse_namespaced_tool_name(request.name) {
+            Ok((plugin_name, tool_name)) => (plugin_name, tool_name),
+            Err(e) => {
+                return Err(McpError::invalid_request(
+                    format!("Failed to parse tool name: {e}"),
+                    None,
+                ));
             }
-        } else {
-            // If not found directly, check if it has a prefix that needs to be stripped
-            for plugin_cfg in &self.config.plugins {
-                if let Some(rt_config) = &plugin_cfg.runtime_config {
-                    if let Some(tool_name_prefix) = &rt_config.tool_name_prefix {
-                        if tool_name_str.starts_with(tool_name_prefix) {
-                            // Strip the prefix to get the original tool name
-                            original_name = tool_name_str[tool_name_prefix.len()..].to_string();
-                            log::info!(
-                                "Stripping prefix from tool: {tool_name_str} -> {original_name}"
-                            );
-
-                            // Check if the original tool name is in the cache
-                            if let Some(plugin_name) = tool_cache.get(&original_name) {
-                                plugin_name_for_tool = Some(plugin_name.clone());
-                                break;
-                            }
-                        }
-                    }
-                }
+        };
+        let plugin_config = match self.config.plugins.get(&plugin_name) {
+            Some(config) => config,
+            None => {
+                return Err(McpError::method_not_found::<CallToolRequestMethod>());
+            }
+        };
+        if let Some(skip_tools) = &plugin_config
+            .runtime_config
+            .as_ref()
+            .and_then(|rc| rc.skip_tools.clone())
+        {
+            if skip_tools.iter().any(|s| s == &tool_name) {
+                log::info!("Tool {tool_name} in skip_tools");
+                return Err(McpError::method_not_found::<CallToolRequestMethod>());
             }
         }
 
-        // Create a modified request with the original tool name
-        let mut modified_request = request.clone();
-        // Convert the String to Cow<'static, str> using into()
-        modified_request.name = std::borrow::Cow::Owned(original_name);
-
         let call_payload = json!({
-            "params": modified_request,
+            "params": CallToolRequestParam {
+                name: std::borrow::Cow::Owned(tool_name),
+                arguments: request.arguments,
+            },
         });
         let json_string =
             serde_json::to_string(&call_payload).expect("Failed to serialize request");
 
-        // Check if the tool exists in the cache
-        if let Some(plugin_name) = plugin_name_for_tool {
-            if let Some(plugin_arc) = plugins.get(&plugin_name) {
-                let plugin_clone = Arc::clone(plugin_arc);
-                let plugin_name_clone = plugin_name.clone();
+        let plugins = self.plugins.read().await;
 
-                let result = tokio::task::spawn_blocking(move || {
-                    let mut plugin = plugin_clone.lock().unwrap();
-                    plugin.call::<&str, String>("call", &json_string)
-                })
-                .await;
+        if let Some(plugin_arc) = plugins.get(&plugin_name) {
+            let plugin_clone = Arc::clone(plugin_arc);
 
-                return match result {
-                    Ok(Ok(result)) => match serde_json::from_str::<CallToolResult>(&result) {
-                        Ok(parsed) => Ok(parsed),
-                        Err(e) => Err(McpError::internal_error(
-                            format!("Failed to deserialize data: {e}"),
-                            None,
-                        )),
-                    },
-                    Ok(Err(e)) => Err(McpError::internal_error(
-                        format!("Failed to execute plugin {plugin_name_clone}: {e}"),
-                        None,
-                    )),
+            return match tokio::task::spawn_blocking(move || {
+                let mut plugin = plugin_clone.lock().unwrap();
+                plugin.call::<&str, String>("call", &json_string)
+            })
+            .await
+            {
+                Ok(Ok(result)) => match serde_json::from_str::<CallToolResult>(&result) {
+                    Ok(parsed) => Ok(parsed),
                     Err(e) => Err(McpError::internal_error(
-                        format!(
-                            "Failed to spawn blocking task for plugin {plugin_name_clone}: {e}"
-                        ),
+                        format!("Failed to deserialize data: {e}"),
                         None,
                     )),
-                };
-            }
+                },
+                Ok(Err(e)) => Err(McpError::internal_error(
+                    format!("Failed to execute plugin {plugin_name}: {e}"),
+                    None,
+                )),
+                Err(e) => Err(McpError::internal_error(
+                    format!("Failed to spawn blocking task for plugin {plugin_name}: {e}"),
+                    None,
+                )),
+            };
         }
 
         Err(McpError::method_not_found::<CallToolRequestMethod>())
@@ -357,88 +320,71 @@ impl ServerHandler for PluginService {
         _context: RequestContext<RoleServer>,
     ) -> std::result::Result<ListToolsResult, McpError> {
         tracing::info!("got tools/list request {:?}", request);
-        let plugins = self.plugins.write().await;
-        let mut tool_cache = self.tool_plugin_map.write().await;
+        let plugins = self.plugins.read().await;
 
         let mut payload = ListToolsResult::default();
 
-        // Clear the existing cache when listing tools
-        tool_cache.clear();
+        for (plugin_name, plugin) in plugins.iter() {
+            let plugin_name = plugin_name.clone();
+            let plugin = Arc::clone(plugin);
+            let plugin_cfg = self.config.plugins.get(&plugin_name).ok_or_else(|| {
+                McpError::internal_error(
+                    format!("Plugin configuration not found for {plugin_name}"),
+                    None,
+                )
+            })?;
+            let skip_tools = plugin_cfg
+                .runtime_config
+                .as_ref()
+                .and_then(|rc| rc.skip_tools.clone())
+                .unwrap_or_default();
 
-        for plugin_cfg in &self.config.plugins {
-            if let Some(plugin_arc) = plugins.get(&plugin_cfg.name) {
-                let plugin_clone = Arc::clone(plugin_arc);
-                let plugin_name = plugin_cfg.name.clone();
-
-                let result = tokio::task::spawn_blocking(move || {
-                    let mut plugin = plugin_clone.lock().unwrap();
-                    plugin.call::<&str, String>("describe", "")
-                })
-                .await;
-
-                match result {
-                    Ok(Ok(result)) => {
-                        if let Ok(parsed) = serde_json::from_str::<ListToolsResult>(&result) {
-                            let skip_tools = plugin_cfg
-                                .runtime_config
-                                .as_ref()
-                                .and_then(|rc| rc.skip_tools.clone())
-                                .unwrap_or_default();
-                            for mut tool in parsed.tools {
-                                if skip_tools.iter().any(|s| s == tool.name.as_ref() as &str) {
-                                    log::info!(
-                                        "Skipping tool {} as requested in skip_tools",
-                                        tool.name
+            match tokio::task::spawn_blocking(move || {
+                let mut plugin = plugin.lock().unwrap();
+                plugin.call::<&str, String>("describe", "")
+            })
+            .await
+            {
+                Ok(Ok(result)) => {
+                    if let Ok(parsed) = serde_json::from_str::<ListToolsResult>(&result) {
+                        for mut tool in parsed.tools {
+                            let tool_name = tool.name.as_ref() as &str;
+                            if skip_tools.iter().any(|s| s == tool_name) {
+                                log::info!(
+                                    "Skipping tool {} as requested in skip_tools",
+                                    tool.name
+                                );
+                                continue;
+                            }
+                            tool.name = std::borrow::Cow::Owned(match create_namespaced_tool_name(
+                                &plugin_name,
+                                tool_name,
+                            ) {
+                                Ok(namespaced) => namespaced,
+                                Err(_) => {
+                                    log::error!(
+                                        "Tool name {} in plugin {} contains '::', which is not allowed. Skipping this tool to avoid ambiguity.",
+                                        tool_name,
+                                        plugin_name
                                     );
                                     continue;
                                 }
-                                // If tool_name_prefix is set, append it to the tool name
-                                let original_name = tool.name.to_string();
-                                if let Some(runtime_cfg) = &plugin_cfg.runtime_config {
-                                    if let Some(tool_name_prefix) = &runtime_cfg.tool_name_prefix {
-                                        let prefixed_name =
-                                            format!("{tool_name_prefix}{original_name}");
-                                        log::info!(
-                                            "Adding prefix to tool: {original_name} -> {prefixed_name}"
-                                        );
-
-                                        // Store both the original and prefixed tool names in the cache
-                                        // This ensures we can find the tool by either name
-                                        tool_cache
-                                            .insert(original_name.clone(), plugin_cfg.name.clone());
-
-                                        // Update the tool name with the prefix
-                                        tool.name = std::borrow::Cow::Owned(prefixed_name);
-                                    }
-                                }
-
-                                // Store the tool name (which might be prefixed now) -> plugin mapping
-                                tool_cache.insert(tool.name.to_string(), plugin_cfg.name.clone());
-                                payload.tools.push(tool);
-                            }
+                            });
+                            payload.tools.push(tool);
                         }
                     }
-                    Ok(Err(e)) => {
-                        log::error!("tool {plugin_name} describe() error: {e}");
-                    }
-                    Err(e) => {
-                        log::error!("tool {plugin_name} spawn_blocking error: {e}");
-                    }
+                }
+                Ok(Err(e)) => {
+                    log::error!("{plugin_name} describe() error: {e}");
+                }
+                Err(e) => {
+                    log::error!("{plugin_name} spawn_blocking error: {e}");
                 }
             }
         }
 
         Ok(payload)
     }
-
-    // fn list_tools(
-    //     &self,
-    //     _request: Option<PaginatedRequestParam>,
-    //     _context: RequestContext<RoleServer>,
-    // ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
-    //     tracing::info!("got tools/list request {:?}", _request);
-    //     std::future::ready(Ok(ListToolsResult::default()))
-    // }
 
     fn initialize(
         &self,
@@ -488,5 +434,38 @@ impl ServerHandler for PluginService {
     ) -> impl Future<Output = std::result::Result<CompleteResult, McpError>> + Send + '_ {
         tracing::info!("got complete request {:?}", request);
         std::future::ready(Err(McpError::method_not_found::<CompleteRequestMethod>()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_tool_name() {
+        let plugin_name = PluginName::from_str("example_plugin").unwrap();
+        let tool_name = "example_tool";
+        let expected = "example_plugin::example_tool";
+        assert_eq!(
+            create_namespaced_tool_name(&plugin_name, tool_name).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_parse_tool_name() {
+        let tool_name = "example_plugin::example_tool".to_string();
+        let result = parse_namespaced_tool_name(std::borrow::Cow::Owned(tool_name));
+        assert!(result.is_ok());
+        let (plugin_name, tool) = result.unwrap();
+        assert_eq!(plugin_name.as_str(), "example_plugin");
+        assert_eq!(tool, "example_tool");
+    }
+
+    #[test]
+    fn test_create_tool_name_invalid() {
+        let plugin_name = PluginName::from_str("example_plugin").unwrap();
+        let tool_name = "invalid::tool";
+        assert!(create_namespaced_tool_name(&plugin_name, tool_name).is_err());
     }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -363,9 +363,7 @@ impl ServerHandler for PluginService {
                                 Ok(namespaced) => namespaced,
                                 Err(_) => {
                                     log::error!(
-                                        "Tool name {} in plugin {} contains '::', which is not allowed. Skipping this tool to avoid ambiguity.",
-                                        tool_name,
-                                        plugin_name
+                                        "Tool name {tool_name} in plugin {plugin_name} contains '::', which is not allowed. Skipping this tool to avoid ambiguity.",
                                     );
                                     continue;
                                 }

--- a/tests/fixtures/invalid_plugin_name.yaml
+++ b/tests/fixtures/invalid_plugin_name.yaml
@@ -1,0 +1,12 @@
+plugins:
+  plugin@name:
+    url: "file:///path/to/plugin"
+    runtime_config:
+      skip_tools:
+        - "tool1"
+        - "tool2"
+      allowed_hosts:
+        - "example.com"
+
+  valid-plugin:
+    url: "https://example.com/plugin"

--- a/tests/fixtures/invalid_structure.yaml
+++ b/tests/fixtures/invalid_structure.yaml
@@ -1,0 +1,18 @@
+# This is an invalid structure - missing the 'plugins' top-level map
+test-plugin:
+  url: "file:///path/to/plugin"
+  runtime_config:
+    skip_tools:
+      - "tool1"
+      - "tool2"
+
+# This puts plugins at the wrong level
+configuration:
+  plugins:
+    another-plugin:
+      url: "https://example.com/plugin"
+
+# This has the correct top-level key but incorrect structure
+plugins:
+  - name: minimal-plugin
+    url: "http://localhost:3000/plugin"

--- a/tests/fixtures/invalid_url.yaml
+++ b/tests/fixtures/invalid_url.yaml
@@ -1,0 +1,16 @@
+plugins:
+  valid-plugin:
+    url: "file:///path/to/plugin"
+    runtime_config:
+      skip_tools:
+        - "tool1"
+        - "tool2"
+
+  invalid-url-plugin:
+    url: "not a valid url"
+    runtime_config:
+      allowed_hosts:
+        - "example.com"
+
+  another-valid-plugin:
+    url: "https://example.com/plugin"

--- a/tests/fixtures/valid_config.json
+++ b/tests/fixtures/valid_config.json
@@ -1,0 +1,37 @@
+{
+  "plugins": {
+    "test-plugin": {
+      "url": "file:///path/to/plugin",
+      "runtime_config": {
+        "skip_tools": [
+          "tool1",
+          "tool2"
+        ],
+        "allowed_hosts": [
+          "example.com",
+          "localhost"
+        ],
+        "allowed_paths": [
+          "/tmp",
+          "/var/log"
+        ],
+        "env_vars": {
+          "DEBUG": "true",
+          "LOG_LEVEL": "info"
+        },
+        "memory_limit": "1GB"
+      }
+    },
+    "another-plugin": {
+      "url": "https://example.com/plugin",
+      "runtime_config": {
+        "allowed_hosts": [
+          "api.example.com"
+        ]
+      }
+    },
+    "minimal-plugin": {
+      "url": "http://localhost:3000/plugin"
+    }
+  }
+}

--- a/tests/fixtures/valid_config.yaml
+++ b/tests/fixtures/valid_config.yaml
@@ -1,0 +1,26 @@
+plugins:
+  test-plugin:
+    url: "file:///path/to/plugin"
+    runtime_config:
+      skip_tools:
+        - "tool1"
+        - "tool2"
+      allowed_hosts:
+        - "example.com"
+        - "localhost"
+      allowed_paths:
+        - "/tmp"
+        - "/var/log"
+      env_vars:
+        DEBUG: "true"
+        LOG_LEVEL: "info"
+      memory_limit: "1GB"
+
+  another-plugin:
+    url: "https://example.com/plugin"
+    runtime_config:
+      allowed_hosts:
+        - "api.example.com"
+
+  minimal-plugin:
+    url: "http://localhost:3000/plugin"


### PR DESCRIPTION
Previously hyper-mcp would only namespace tool names if "tool_name_prefix" was present in the config. Additionally, plugins were managed as an array with unique plugin names being enforeced in code.

This PR:

1. Turns the plugin config into a map, enforcing the unique plugin name in the creation of the config file itself (BREAKING)
2. Uses the plugin name to namespace all tools by concatenating the plugin name and the tool name using "::" as the seperator
3. Created validation for plugin and tool names
4. Created unit tests for the above and update the CI actions to incorporate the unit tests