### PR TITLE
Cancellation processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2550,6 +2550,7 @@ dependencies = [
  "docker_credential",
  "extism",
  "flate2",
+ "futures",
  "hex",
  "keyring",
  "log",
@@ -2567,6 +2568,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "toml 0.9.5",
  "tracing",
  "tracing-subscriber",
@@ -4454,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dd163d26e254725137b7933e4ba042ea6bf2d756a4260559aaea8b6ad4c27e"
+checksum = "41ab0892f4938752b34ae47cb53910b1b0921e55e77ddb6e44df666cab17939f"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4485,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43bb4c90a0d4b12f7315eb681a73115d335a2cee81322eca96f3467fe4cd06f"
+checksum = "1827cd98dab34cade0513243c6fe0351f0f0b2c9d6825460bcf45b42804bdda0"
 dependencies = [
  "darling 0.21.2",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,7 +2553,6 @@ dependencies = [
  "futures",
  "hex",
  "keyring",
- "log",
  "oci-client",
  "once_cell",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ keyring = { version = "3.6.3", features = [
     "linux-native",
     "windows-native",
 ] }
-log = "0.4.27"
 oci-client = "0.15.0"
 once_cell = "1.21.3"
 rmcp = { version = "0.6.4", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ keyring = { version = "3.6.3", features = [
 log = "0.4.27"
 oci-client = "0.15.0"
 once_cell = "1.21.3"
-rmcp = { version = "0.6.0", features = [
+rmcp = { version = "0.6.4", features = [
     "server",
     "transport-io",
     "transport-sse-server",
@@ -53,8 +53,10 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
+futures = "0.3.31"
 tempfile = "3.12.0"
 tokio-test = "0.4.4"
+tokio-util = "0.7.16"
 
 [[bin]]
 name = "hyper-mcp"


### PR DESCRIPTION
- Refactors call_tool and list_tools for simplicity
- Upgrades rmcp to 0.6.4
- Adds cancellation processing for call_tool and list_tools
- Swaps out all log calls for tracing
- Updates all call_tool and list_tools unit tests for the new simplified methods
- Adds unit tests for cancellation processing

Fixes #109 