### PR TITLE
Skip tools regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1702,7 +1702,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1888,7 +1888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3143,7 +3143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4341,9 +4341,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4353,9 +4353,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4590,7 +4590,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5479,7 +5479,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rmcp = { version = "0.6.4", features = [
     "transport-sse-server",
     "transport-streamable-http-server",
 ] }
-regex = { version = "1.11.1", features = ["unicode", "perf"] }
+regex = { version = "1.11.3", features = ["unicode", "perf"] }
 reqwest = { version = "0.12.21", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM rust:1.86 AS builder
+FROM --platform=$BUILDPLATFORM rust:1.90 AS builder
 WORKDIR /app
 RUN cargo install cargo-auditable
 
@@ -10,10 +10,10 @@ RUN cargo auditable build --release --locked
 FROM gcr.io/distroless/cc-debian12
 
 LABEL org.opencontainers.image.authors="me@tuananh.org" \
-      org.opencontainers.image.url="https://github.com/tuananh/hyper-mcp" \
-      org.opencontainers.image.source="https://github.com/tuananh/hyper-mcp" \
-      org.opencontainers.image.vendor="github.com/tuananh/hyper-mcp" \
-      io.modelcontextprotocol.server.name="io.github.tuananh/hyper-mcp"
+    org.opencontainers.image.url="https://github.com/tuananh/hyper-mcp" \
+    org.opencontainers.image.source="https://github.com/tuananh/hyper-mcp" \
+    org.opencontainers.image.vendor="github.com/tuananh/hyper-mcp" \
+    io.modelcontextprotocol.server.name="io.github.tuananh/hyper-mcp"
 
 WORKDIR /app
 COPY --from=builder /app/target/release/hyper-mcp /usr/local/bin/hyper-mcp

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ We maintain several example plugins to get you started:
   - Security considerations and best practices
   - Platform-specific keyring setup for macOS, Linux, and Windows
   - Troubleshooting authentication issues
+- **[Skip Tools Pattern Guide](./SKIP_TOOLS_GUIDE.md)** - Comprehensive guide to filtering tools using regex patterns:
+  - Pattern syntax and examples
+  - Common use cases and best practices
+  - Environment-specific filtering strategies
+  - Advanced regex techniques
+  - Migration and troubleshooting
 
 ## Creating Plugins
 

--- a/SKIP_TOOLS_GUIDE.md
+++ b/SKIP_TOOLS_GUIDE.md
@@ -1,0 +1,467 @@
+# Skip Tools Pattern Guide
+
+This guide provides comprehensive documentation for using the `skip_tools` configuration in hyper-mcp, which allows you to filter out unwanted tools using powerful regex patterns.
+
+## Overview
+
+The `skip_tools` field in your plugin's `runtime_config` allows you to specify a list of regex patterns that will be used to exclude tools from being loaded at runtime. This is useful for:
+
+- Removing debug tools in production environments
+- Filtering out deprecated or experimental tools
+- Excluding tools that conflict with your workflow
+- Customizing the available tool set per environment
+
+## How It Works
+
+### Automatic Pattern Anchoring
+
+All patterns in `skip_tools` are automatically anchored to match the entire tool name. This means:
+
+```yaml
+skip_tools:
+  - "debug"  # Becomes "^debug$" - matches exactly "debug"
+```
+
+This prevents unintended partial matches. If you want to match parts of tool names, use explicit wildcards:
+
+```yaml
+skip_tools:
+  - "debug.*"  # Matches "debug", "debugger", "debug_info", etc.
+```
+
+### Regex Compilation
+
+All patterns are compiled into a single optimized `RegexSet` for efficient matching:
+- O(1) lookup time regardless of pattern count
+- Single compilation at startup
+- Memory-efficient pattern storage
+
+## Basic Patterns
+
+### Exact Matches
+
+Match specific tool names exactly:
+
+```yaml
+skip_tools:
+  - "debug_tool"      # Matches only "debug_tool"
+  - "test_runner"     # Matches only "test_runner"
+  - "admin_panel"     # Matches only "admin_panel"
+```
+
+### Prefix Matching
+
+Match tools that start with a specific string:
+
+```yaml
+skip_tools:
+  - "debug.*"         # Matches "debug", "debugger", "debug_info"
+  - "test_.*"         # Matches "test_unit", "test_integration", "test_e2e"
+  - "dev_.*"          # Matches "dev_server", "dev_tools", "dev_helper"
+```
+
+### Suffix Matching
+
+Match tools that end with a specific string:
+
+```yaml
+skip_tools:
+  - ".*_test"         # Matches "unit_test", "integration_test", "load_test"
+  - ".*_backup"       # Matches "data_backup", "config_backup", "db_backup"
+  - ".*_deprecated"   # Matches "old_deprecated", "legacy_deprecated"
+```
+
+### Contains Matching
+
+Match tools that contain a specific substring:
+
+```yaml
+skip_tools:
+  - ".*debug.*"       # Matches "pre_debug_tool", "debug", "tool_debug_info"
+  - ".*temp.*"        # Matches "temp_file", "cleanup_temp", "temp_storage_tool"
+```
+
+## Advanced Patterns
+
+### Character Classes
+
+Use character classes for flexible matching:
+
+```yaml
+skip_tools:
+  - "tool_[0-9]+"           # Matches "tool_1", "tool_42", "tool_999"
+  - "test_[a-z]+"           # Matches "test_unit", "test_api", "test_db"
+  - "[A-Z][a-z]+Tool"       # Matches "DebugTool", "TestTool", "AdminTool"
+  - "log_[0-9]{4}_[0-9]{2}" # Matches "log_2023_12", "log_2024_01"
+```
+
+### Alternation (OR Logic)
+
+Match multiple alternatives:
+
+```yaml
+skip_tools:
+  - "test_(unit|integration|e2e)"     # Matches "test_unit", "test_integration", "test_e2e"
+  - "(debug|trace|log)_.*"            # Matches tools starting with "debug_", "trace_", or "log_"
+  - ".*(temp|tmp|cache).*"            # Matches tools containing "temp", "tmp", or "cache"
+  - "system_(admin|user|guest)_.*"    # Matches tools for different user types
+```
+
+### Quantifiers
+
+Control how many characters or groups to match:
+
+```yaml
+skip_tools:
+  - "tool_v[0-9]+"          # Matches "tool_v1", "tool_v10", "tool_v123"
+  - "backup_[0-9]{8}"       # Matches exactly 8 digits: "backup_20240101"
+  - "temp_[a-f0-9]{6,}"     # Matches 6+ hex chars: "temp_abc123", "temp_def456789"
+  - "log_[0-9]{4}-[0-9]{2}" # Matches "log_2024-01", "log_2023-12"
+```
+
+### Negation with Character Classes
+
+Skip tools that DON'T match certain patterns:
+
+```yaml
+skip_tools:
+  - "[^a-z].*"              # Skip tools starting with non-lowercase letters
+  - ".*[^0-9]$"             # Skip tools not ending with numbers
+  - "tool_[^v].*"           # Skip tools starting with "tool_" but not "tool_v"
+```
+
+## Common Use Cases
+
+### Environment-Specific Filtering
+
+#### Development Environment
+```yaml
+skip_tools:
+  - "prod_.*"               # Skip production tools
+  - "deploy_.*"             # Skip deployment tools
+  - "monitor_.*"            # Skip monitoring tools
+```
+
+#### Production Environment
+```yaml
+skip_tools:
+  - "debug.*"               # Skip all debug tools
+  - "test_.*"               # Skip all test tools
+  - "dev_.*"                # Skip development tools
+  - "mock_.*"               # Skip mock/stub tools
+  - ".*_experimental"       # Skip experimental features
+```
+
+#### Testing Environment
+```yaml
+skip_tools:
+  - "prod_.*"               # Skip production tools
+  - "deploy_.*"             # Skip deployment tools
+  - ".*_live"               # Skip live/production tools
+```
+
+### Tool Category Filtering
+
+#### Skip Administrative Tools
+```yaml
+skip_tools:
+  - "admin_.*"
+  - "system_admin_.*"
+  - "user_management_.*"
+  - "permission_.*"
+```
+
+#### Skip Deprecated Tools
+```yaml
+skip_tools:
+  - ".*_deprecated"
+  - ".*_old"
+  - "legacy_.*"
+  - "v[0-9]_.*"             # Skip versioned legacy tools
+```
+
+#### Skip Resource-Heavy Tools
+```yaml
+skip_tools:
+  - ".*_benchmark"
+  - "load_test_.*"
+  - "stress_.*"
+  - "heavy_.*"
+```
+
+### Version-Based Filtering
+
+```yaml
+skip_tools:
+  - ".*_v[0-9]"             # Skip v1, v2, etc. (keep latest)
+  - ".*_beta"               # Skip beta tools
+  - ".*_alpha"              # Skip alpha tools
+  - "tool_[0-9]+\\.[0-9]+"  # Skip versioned tools like "tool_1.0"
+```
+
+## Special Character Escaping
+
+When matching literal special characters, escape them with backslashes:
+
+```yaml
+skip_tools:
+  - "file\\.exe"            # Matches "file.exe" literally
+  - "script\\?"             # Matches "script?" literally
+  - "temp\\*data"           # Matches "temp*data" literally
+  - "path\\\\tool"          # Matches "path\tool" literally (double escape for backslash)
+  - "price\\$calculator"    # Matches "price$calculator" literally
+  - "regex\\[test\\]"       # Matches "regex[test]" literally
+```
+
+## Configuration Examples
+
+### Simple Configuration
+```yaml
+plugins:
+  my_plugin:
+    url: "oci://registry.io/my-plugin:latest"
+    runtime_config:
+      skip_tools:
+        - "debug_tool"
+        - "test_runner"
+```
+
+### Comprehensive Configuration
+```yaml
+plugins:
+  production_plugin:
+    url: "oci://registry.io/prod-plugin:latest"
+    runtime_config:
+      skip_tools:
+        # Exact matches
+        - "debug_console"
+        - "test_runner"
+        
+        # Pattern matches
+        - "dev_.*"              # All dev tools
+        - ".*_test"             # All test tools
+        - "temp_.*"             # All temp tools
+        - "mock_.*"             # All mock tools
+        
+        # Advanced patterns
+        - "tool_v[0-9]"         # Versioned tools
+        - "admin_(user|role)_.*" # Specific admin tools
+        - "[0-9]+_backup"       # Numbered backups
+        
+      allowed_hosts: ["api.example.com"]
+      memory_limit: "512Mi"
+```
+
+### Multi-Environment Setup
+```yaml
+# config.dev.yaml
+plugins:
+  app_plugin:
+    url: "oci://registry.io/app-plugin:dev"
+    runtime_config:
+      skip_tools:
+        - "prod_.*"
+        - "deploy_.*"
+
+---
+# config.prod.yaml  
+plugins:
+  app_plugin:
+    url: "oci://registry.io/app-plugin:latest"
+    runtime_config:
+      skip_tools:
+        - "debug.*"
+        - "test_.*"
+        - "dev_.*"
+        - ".*_experimental"
+```
+
+## Best Practices
+
+### 1. Start Simple, Then Refine
+```yaml
+# Start with broad patterns
+skip_tools:
+  - "debug.*"
+  - "test_.*"
+
+# Refine to be more specific as needed
+skip_tools:
+  - "debug_(console|panel)"  # Only skip specific debug tools
+  - "test_(unit|integration)" # Only skip specific test types
+```
+
+### 2. Use Comments for Complex Patterns
+```yaml
+skip_tools:
+  - "tool_[0-9]+"             # Skip numbered tools (tool_1, tool_2, etc.)
+  - ".*_(alpha|beta|rc[0-9]+)" # Skip pre-release versions
+  - "temp_[0-9]{8}_.*"        # Skip dated temporary tools
+```
+
+### 3. Group Related Patterns
+```yaml
+skip_tools:
+  # Debug and development tools
+  - "debug.*"
+  - "dev_.*"
+  - ".*_dev"
+  
+  # Testing tools
+  - "test_.*"
+  - ".*_test"
+  - "mock_.*"
+  
+  # Administrative tools
+  - "admin_.*"
+  - "system_.*"
+```
+
+### 4. Consider Performance
+```yaml
+# Good: Specific patterns
+skip_tools:
+  - "debug_tool"
+  - "test_runner"
+
+# Less optimal: Overly broad patterns that might match many tools
+skip_tools:
+  - ".*"  # This would skip everything - not useful
+```
+
+## Troubleshooting
+
+### Pattern Not Working?
+
+1. **Check anchoring**: Remember patterns are auto-anchored
+   ```yaml
+   # This matches only "debug" exactly
+   - "debug"
+   
+   # This matches "debug", "debugger", "debug_tool", etc.
+   - "debug.*"
+   ```
+
+2. **Escape special characters**:
+   ```yaml
+   # Wrong: Will treat . as wildcard
+   - "file.exe"
+   
+   # Correct: Escapes the literal dot
+   - "file\\.exe"
+   ```
+
+3. **Test your patterns**: Use a regex tester to validate complex patterns
+
+### Debugging Skip Rules
+
+Enable debug logging to see which tools are being skipped:
+
+```bash
+RUST_LOG=debug hyper-mcp --config config.yaml
+```
+
+## Migration from Old Format
+
+If you were using simple string arrays before:
+
+```yaml
+# Old format (if it existed)
+skip_tools: ["debug_tool", "test_runner"]
+
+# New format (same result, but now with regex support)
+skip_tools: ["debug_tool", "test_runner"]
+
+# New format with patterns (more powerful)
+skip_tools: ["debug.*", "test_.*"]
+```
+
+## Error Handling
+
+### Invalid Regex Patterns
+
+If you provide an invalid regex pattern, configuration loading will fail:
+
+```yaml
+# This will cause an error - unclosed bracket
+skip_tools:
+  - "tool_[invalid"
+```
+
+Error message will indicate the problematic pattern and suggest corrections.
+
+### Empty Patterns
+
+These configurations are all valid:
+
+```yaml
+# No skip_tools field - no tools skipped
+runtime_config:
+  allowed_hosts: ["*"]
+
+# Empty array - no tools skipped  
+runtime_config:
+  skip_tools: []
+
+# Null value - no tools skipped
+runtime_config:
+  skip_tools: null
+```
+
+## Performance Characteristics
+
+- **Startup**: O(n) pattern compilation where n = number of patterns
+- **Runtime**: O(1) tool name checking regardless of pattern count
+- **Memory**: Minimal overhead, patterns compiled into efficient state machine
+- **Scalability**: Handles hundreds of patterns efficiently
+
+## Advanced Topics
+
+### Complex Business Logic
+
+```yaml
+skip_tools:
+  # Skip tools for specific environments
+  - "prod_(?!api_).*"         # Skip prod tools except prod_api_*
+  - "test_(?!smoke_).*"       # Skip test tools except smoke tests
+  
+  # Skip based on naming conventions
+  - "[A-Z]{2,}_.*"            # Skip tools starting with 2+ capitals
+  - ".*_[0-9]{4}[0-9]{2}[0-9]{2}" # Skip daily-dated tools
+```
+
+### Integration with External Tools
+
+You can generate `skip_tools` patterns dynamically:
+
+```bash
+# Generate patterns from external source
+echo "skip_tools:" > config.yaml
+external-tool --list-deprecated | sed 's/^/  - "/' | sed 's/$/\"/' >> config.yaml
+```
+
+### Conditional Configuration
+
+Use different configs for different scenarios:
+
+```yaml
+# Base configuration
+base_skip_patterns: &base_skip
+  - "debug.*"
+  - "test_.*"
+
+# Environment-specific additions
+prod_additional: &prod_additional
+  - "dev_.*"
+  - ".*_experimental"
+
+plugins:
+  my_plugin:
+    runtime_config:
+      skip_tools:
+        - *base_skip
+        - *prod_additional  # YAML doesn't support this directly, 
+                            # but you can use templating tools
+```
+
+This guide should help you make full use of the powerful `skip_tools` pattern matching capabilities in hyper-mcp!

--- a/config.example.json
+++ b/config.example.json
@@ -12,13 +12,29 @@
     "myip": {
       "url": "oci://ghcr.io/tuananh/myip-plugin:latest",
       "runtime_config": {
-        "allowed_hosts": ["1.1.1.1"]
+        "allowed_hosts": ["1.1.1.1"],
+        "skip_tools": ["debug_.*", ".*_test"]
       }
     },
     "fetch": {
       "url": "oci://ghcr.io/tuananh/fetch-plugin:latest",
       "runtime_config": {
-        "allowed_hosts": ["*"]
+        "allowed_hosts": ["*"],
+        "skip_tools": ["temp_.*", "mock_.*", "tool_[0-9]+"]
+      }
+    },
+    "example_plugin": {
+      "url": "oci://ghcr.io/example/demo-plugin:latest",
+      "runtime_config": {
+        "skip_tools": [
+          "admin_tool",
+          "dev_.*",
+          ".*_deprecated",
+          "test_(unit|integration)",
+          "[a-z]+_helper"
+        ],
+        "allowed_hosts": ["example.com"],
+        "memory_limit": "256Mi"
       }
     }
   }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,8 +11,29 @@ plugins:
     runtime_config:
       allowed_hosts:
         - "1.1.1.1"
+      skip_tools:
+        - "debug_.*" # Skip all debug tools
+        - ".*_test" # Skip all test tools
   fetch:
     url: oci://ghcr.io/tuananh/fetch-plugin:latest
     runtime_config:
       allowed_hosts:
         - "*"
+      skip_tools:
+        - "temp_.*" # Skip temporary tools
+        - "mock_.*" # Skip mock tools
+        - "tool_[0-9]+" # Skip numbered tools like "tool_1", "tool_42"
+
+  # Example plugin with comprehensive skip_tools patterns
+  example_plugin:
+    url: oci://ghcr.io/example/demo-plugin:latest
+    runtime_config:
+      skip_tools:
+        - "admin_tool" # Skip exact tool name
+        - "dev_.*" # Skip development tools
+        - ".*_deprecated" # Skip deprecated tools
+        - "test_(unit|integration)" # Skip specific test types
+        - "[a-z]+_helper" # Skip lowercase helpers
+      allowed_hosts:
+        - "example.com"
+      memory_limit: "256Mi"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.90"
 components = ["rustc", "rust-std", "cargo", "clippy", "rustfmt"]

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -4,7 +4,6 @@ use docker_credential::{CredentialRetrievalError, DockerCredential};
 use flate2::read::GzDecoder;
 use oci_client::Reference;
 use oci_client::{Client, manifest, manifest::OciDescriptor, secrets::RegistryAuth};
-use serde::{Deserialize, Serialize};
 use sigstore::cosign::verification_constraint::cert_subject_email_verifier::StringVerifier;
 use sigstore::cosign::verification_constraint::{
     CertSubjectEmailVerifier, CertSubjectUrlVerifier, VerificationConstraintVec,
@@ -19,33 +18,6 @@ use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;
 use tar::Archive;
-
-// Docker manifest format v2
-#[derive(Debug, Serialize, Deserialize)]
-struct DockerManifest {
-    #[serde(rename = "schemaVersion")]
-    schema_version: u32,
-    #[serde(rename = "mediaType")]
-    media_type: String,
-    config: DockerManifestConfig,
-    layers: Vec<DockerManifestLayer>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct DockerManifestConfig {
-    #[serde(rename = "mediaType")]
-    media_type: String,
-    size: u64,
-    digest: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct DockerManifestLayer {
-    #[serde(rename = "mediaType")]
-    media_type: String,
-    size: u64,
-    digest: String,
-}
 
 fn build_auth(reference: &Reference) -> RegistryAuth {
     let server = reference

--- a/tests/fixtures/skip_tools_examples.yaml
+++ b/tests/fixtures/skip_tools_examples.yaml
@@ -1,0 +1,102 @@
+# Test configuration file demonstrating various skip_tools functionality
+plugins:
+  # Plugin with exact tool name matches
+  exact_match_plugin:
+    url: "file:///path/to/exact_plugin"
+    runtime_config:
+      skip_tools:
+        - "debug_tool"
+        - "test_runner"
+        - "deprecated_helper"
+
+  # Plugin with wildcard patterns
+  wildcard_plugin:
+    url: "https://example.com/wildcard_plugin"
+    runtime_config:
+      skip_tools:
+        - "temp_.*"       # Skip any tool starting with "temp_"
+        - ".*_backup"     # Skip any tool ending with "_backup"
+        - "debug.*"       # Skip any tool starting with "debug"
+
+  # Plugin with complex regex patterns
+  regex_plugin:
+    url: "http://localhost:3000/regex_plugin"
+    runtime_config:
+      skip_tools:
+        - "tool_[0-9]+"           # Skip tools like "tool_1", "tool_42"
+        - "test_(unit|integration)" # Skip "test_unit" and "test_integration"
+        - "[a-z]+_helper"         # Skip lowercase word followed by "_helper"
+
+  # Plugin with anchored patterns (already have anchors)
+  anchored_plugin:
+    url: "file:///path/to/anchored_plugin"
+    runtime_config:
+      skip_tools:
+        - "^system_.*"    # Explicit start anchor
+        - ".*_internal$"  # Explicit end anchor
+        - "^exact_only$"  # Fully anchored
+
+  # Plugin with case-sensitive patterns
+  case_sensitive_plugin:
+    url: "https://api.example.com/case_plugin"
+    runtime_config:
+      skip_tools:
+        - "Tool"          # Only matches "Tool", not "tool" or "TOOL"
+        - "DEBUG_.*"      # Only matches uppercase DEBUG prefix
+        - "CamelCase.*"   # Matches tools starting with "CamelCase"
+
+  # Plugin with special regex characters escaped
+  special_chars_plugin:
+    url: "file:///path/to/special_plugin"
+    runtime_config:
+      skip_tools:
+        - "file\\.exe"    # Matches "file.exe" literally
+        - "script\\?"     # Matches "script?" literally
+        - "temp\\*data"   # Matches "temp*data" literally
+        - "path\\\\tool"  # Matches "path\tool" literally
+
+  # Plugin with empty skip_tools (skip nothing)
+  empty_skip_plugin:
+    url: "https://example.com/empty_plugin"
+    runtime_config:
+      skip_tools: []
+      allowed_hosts:
+        - "example.com"
+
+  # Plugin with no skip_tools specified (defaults to None)
+  no_skip_plugin:
+    url: "file:///path/to/no_skip_plugin"
+    runtime_config:
+      allowed_hosts:
+        - "localhost"
+      memory_limit: "512MB"
+
+  # Plugin demonstrating mixed runtime config with skip_tools
+  full_config_plugin:
+    url: "https://secure.example.com/full_plugin"
+    runtime_config:
+      skip_tools:
+        - "admin_.*"
+        - ".*_dangerous"
+        - "system_critical"
+      allowed_hosts:
+        - "api.example.com"
+        - "cdn.example.com"
+      allowed_paths:
+        - "/tmp"
+        - "/var/app/data"
+      env_vars:
+        ENVIRONMENT: "test"
+        LOG_LEVEL: "debug"
+      memory_limit: "2GB"
+
+  # Plugin with common tool patterns to skip
+  common_patterns_plugin:
+    url: "file:///path/to/common_plugin"
+    runtime_config:
+      skip_tools:
+        - ".*_test"       # Skip all test tools
+        - "dev_.*"        # Skip all development tools
+        - "mock_.*"       # Skip all mock tools
+        - "stub_.*"       # Skip all stub tools
+        - ".*_deprecated" # Skip all deprecated tools


### PR DESCRIPTION
Changes skip_tools to use regexes instead of direct string matching.

If there are any anchors present, we assume that the user knows what they are doing. If not, we add anchors so the "foobar" becomes "^foobar&" and does exactly what the user used to expect, while still allowing "^foo.*" and "foo.*$" and "^foo.*$".

Uses RegexSet for high-perf matching.

Fixes #114 